### PR TITLE
Update database example

### DIFF
--- a/config/database.example.yml
+++ b/config/database.example.yml
@@ -1,25 +1,25 @@
 # SQLite version 3.x
 #   gem install sqlite3-ruby (not necessary on OS X Leopard)
+
+default: &default
+  adapter: postgresql
+  host: localhost
+
 development:
-  adapter: sqlite3
-  database: db/development.sqlite3
-  pool: 5
-  timeout: 5000
+  <<: *default
+  database: bostonrb-dev
+  
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test: &test
-  adapter: sqlite3
-  database: db/test.sqlite3
-  pool: 5
-  timeout: 5000
+  <<: *default
+  database: bostonrb-test
 
 production:
-  adapter: sqlite3
-  database: db/production.sqlite3
-  pool: 5
-  timeout: 5000
+  <<: *default
+  database: bostonrb-prod
 
 cucumber:
   <<: *test


### PR DESCRIPTION
Update to the config/database.yml.example file to reflect that the DB is Postgres instead of sqlite.  Since sqlite3 is no longer packaged in bundler you'll run into errors when following the directions on the readme.
