### PR TITLE
Removing RSpec deprecation warning by only using one RSpec config block.

### DIFF
--- a/spec/acceptance/acceptance_helper.rb
+++ b/spec/acceptance/acceptance_helper.rb
@@ -8,4 +8,7 @@ RSpec.configure do |config|
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
   config.use_transactional_fixtures = true
   config.include Rails.application.routes.url_helpers, :type => :request
+  
+  config.include EmailSpec::Helpers
+  config.include EmailSpec::Matchers
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,4 @@ RSpec.configure do |config|
   # examples within a transaction, remove the following line or assign false
   # instead of true.
   config.use_transactional_fixtures = true
-  
-  config.include EmailSpec::Helpers
-  config.include EmailSpec::Matchers  
 end


### PR DESCRIPTION
RSpec 3.0 won't allow you run the Rspec.config method more than once and gives you a nice little nastygram if you attempt to:

```
*****************************************************************
DEPRECATION WARNING: you are using deprecated behaviour that will
be removed from RSpec 3.

You have set some configuration options after an example group has
already been defined.  In RSpec 3, this will not be allowed.  All
configuration should happen before the first example group is
defined.  The configuration is happening at:

 /Users/patricksrobertson/projects/prob/bostonrb/spec/acceptance/support/email_spec.rb:1:in `<top     (required)>'
*****************************************************************
```

The fix is really simple.  It won't have any significant overhead on testing execution times.
