### PR TITLE
Consistent use of Time::DATE_FORMATS[]

### DIFF
--- a/app/helpers/presentations_helper.rb
+++ b/app/helpers/presentations_helper.rb
@@ -1,7 +1,7 @@
 module PresentationsHelper
   def presentations_index_header
     if params[:month]
-      Date.parse(params[:month]).strftime('%B %Y')
+      Date.parse(params[:month]).to_time.to_s(:month_and_year)
     else
       'Past presentations'
     end

--- a/app/views/presentations/_date.html.erb
+++ b/app/views/presentations/_date.html.erb
@@ -1,6 +1,6 @@
 <article id="<%= date.to_s -%>" class='date'>
   <header>
-    <h2><%= link_to_unless_current date.to_time.to_s(:date), month_presentations_path(:month => date.strftime('%B-%Y')) %></h2>
+    <h2><%= link_to_unless_current date.to_time.to_s(:date), month_presentations_path(:month => date.to_time.to_s(:month_and_year)) %></h2>
   </header>
   <%= render :partial => 'presentations/presentation', :collection => @grouped_presentations[date] %>
 </article>

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,7 +1,8 @@
 {
  :short_date  => "%x",            # 04/13/10
  :long_date   => "%a, %b %d, %Y", # Tue, Apr 13, 2010
-  :date => '%B %e, %Y'            # April 22, 2011
+ :month_and_year => "%B %Y",      # April 2011
+ :date => '%B %e, %Y'             # April 22, 2011
 }.each do |format_name, format_string|
   Time::DATE_FORMATS[format_name] = format_string
 end


### PR DESCRIPTION
Moved the "August 2011" time and date format to the initializer so that we're a bit more consistent with our formatting.  Wanted to use stamp but this seems to be DRY enough.
