### PR TITLE
Invoke BostonRbCalendar#cache_next_event in the acceptance suite

### DIFF
--- a/lib/boston_rb_calendar.rb
+++ b/lib/boston_rb_calendar.rb
@@ -13,6 +13,10 @@ require 'boston_rb_calendar/request'
 module BostonRbCalendar
   extend Request
 
+  def self.cache_next_event
+    Rails.cache.write(:next_event, next_event)
+  end
+
   def self.next_event
     upcoming_events.first
   end

--- a/lib/tasks/cron.rake
+++ b/lib/tasks/cron.rake
@@ -1,9 +1,4 @@
 desc "Cron Tasks"
 task :cron => :environment do
-  cache_next_event
+  BostonRbCalendar.cache_next_event
 end
-
-def cache_next_event
-  Rails.cache.write(:next_event, BostonRbCalendar.next_event)
-end
-

--- a/spec/acceptance/visitor_finds_general_info_spec.rb
+++ b/spec/acceptance/visitor_finds_general_info_spec.rb
@@ -8,6 +8,7 @@ feature 'Visitor finds general info', %{
 
   before(:all) do
     VCR.insert_cassette('boston_rb_calendar')
+    BostonRbCalendar.cache_next_event
   end
 
   scenario 'Visitor finds general info with no upcoming presentations' do


### PR DESCRIPTION
The test suite can't seem to pass without the cache first being warmed for the next event.  This request moves the method into the BostonRbCalendar so we don't have to do something downright silly as invoke a rake task from a before(:suite) block.  Who would do such a hideous thing as that?
