### PR TITLE
Use a better viewport for iPads.

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="description" content="Boston Ruby is a local community of Rubyists and enthusiasts of open source software.">
-    <meta name="viewport" content = "initial-scale = 0.35,user-scalable = yes">
+    <meta name="viewport" content="width=device-width, maximum-scale=1.0" />
     <title>Boston Ruby Group</title>
     <link rel="icon" href="/favicon.ico">
     <%= stylesheet_link_tag    'application' %>


### PR DESCRIPTION
I'm not entirely sure how I can test this sucker, but it looks considerably better on my iPad.  Max scale is there so we don't blow the page up on landscape view.  This addresses #124
