### PR TITLE
Removes the second RSpec.configure block

### DIFF
--- a/spec/acceptance/acceptance_helper.rb
+++ b/spec/acceptance/acceptance_helper.rb
@@ -4,12 +4,4 @@ require 'capybara/rspec'
 # Put your acceptance spec helpers inside /spec/acceptance/support
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
 
-RSpec.configure do |config|
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
-  config.use_transactional_fixtures = true
-  config.include Rails.application.routes.url_helpers, :type => :request
 
-  config.include EmailSpec::Helpers
-  config.include EmailSpec::Matchers
-  config.extend VCR::RSpec::Macros
-end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,4 +32,8 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = true
   config.extend VCR::RSpec::Macros
+  config.include Rails.application.routes.url_helpers, :type => :request
+
+  config.include EmailSpec::Helpers
+  config.include EmailSpec::Matchers
 end


### PR DESCRIPTION
Having two RSpec.configure blocks results in a deprecation warning (but only on travis-ci.org, for some reason)

Deprecation warning: http://travis-ci.org/#!/danseaver/bostonrb/builds/412013/L184
