### PR TITLE
Fixes .travis.yml and tests that would fail on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,9 @@
 rvm: 1.9.2
+
+before_script:
+  - "cp config/database.example.yml config/database.yml"
+  - "bundle exec rake db:migrate"
+
+notifications:
+  irc: "irc.freenode.org#boston.rb"
+

--- a/spec/models/presentation_spec.rb
+++ b/spec/models/presentation_spec.rb
@@ -20,10 +20,10 @@ describe Presentation do
 
   describe '.past_or_by_month' do
     before do
-      Timecop.freeze(Date.parse('May 10, 2011'))
+      Timecop.freeze(Date.parse('May 20, 2011'))
       @past_presentation_1  = Factory(:presentation, :presented_at => 'April 8, 2011')
       @past_presentation_2  = Factory(:presentation, :presented_at => 'May 9, 2011')
-      @current_presentation = Factory(:presentation, :presented_at => 'May 10, 2011')
+      @current_presentation = Factory(:presentation, :presented_at => 'May 20, 2011')
       @future_presentation  = Factory(:presentation, :presented_at => 'June 11, 2011')
     end
 


### PR DESCRIPTION
Fixes #133

Travis-CI.org would not pass because there was no databse.yml in the
repo. This commit adds 2 before scripts to copy the database.example.yml
to database.yml and run the migrations. It also includes setting up
notifications for the IRC channel.

The tests for Presentation.past_or_by_month was failing on travis due to
timezone issues. I changed the current date for that test so that the
timezone issues would not affect the test suite.
