### PR TITLE
Adds the travis-ci.org status to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ It's a Rails app running [Ruby 1.9](http://www.ruby-lang.org/en/downloads) and u
 * ValidAttribute for model validation testing
 * Factory Girl for test data
 
+Build Status
+------------
+
+[![travis-ci status](https://secure.travis-ci.org/bostonrb/bostonrb.png)](http://travis-ci.org/bostonrb/bostonrb)
+
+
+
 Setup
 -----
 


### PR DESCRIPTION
The travis-ci build status image is a link to the bostonrb project on
travis-ci.org

[ci skip]
