### PR TITLE
Adds Setting model and interface to manage settings

### DIFF
--- a/app/assets/stylesheets/admin.css.scss
+++ b/app/assets/stylesheets/admin.css.scss
@@ -1,4 +1,4 @@
-#new-presentation {
+#new-presentation, #new-setting {
   a {
     background-color: #A41000;
     color: #FFFFFF;
@@ -17,3 +17,24 @@
   font-size: .8em;
 }
 
+section.setting {
+  h2, h3 {
+    font-weight: bold;
+  }
+
+  h2 {
+    font-size:18px;
+    margin: 30px 0 10px 0;
+
+    span {
+      font-weight: normal;
+    }
+  }
+
+  ul {
+    margin-top: 10px;
+    li {
+      display: inline;
+    }
+  }
+}

--- a/app/assets/stylesheets/screen.css.scss
+++ b/app/assets/stylesheets/screen.css.scss
@@ -218,7 +218,7 @@ body.presentations-index {
   }
 }
 
-body.proposals, body.admin-presentations {
+body.proposals, body.admin-presentations, body.admin-settings {
   label {
     font-weight: bold;
     font-size: 16px;

--- a/app/controllers/admin/presentations_controller.rb
+++ b/app/controllers/admin/presentations_controller.rb
@@ -1,6 +1,4 @@
-class Admin::PresentationsController < ApplicationController
-  http_basic_authenticate_with name: BostonRuby::Admin[:username], password: BostonRuby::Admin[:password]
-
+class Admin::PresentationsController < AdminController
   def index
     @presentations = Presentation.all_or_by_month(:page => params[:page], :per => params[:per], :month => params[:month])
     @grouped_presentations = @presentations.group_by_date
@@ -28,8 +26,6 @@ class Admin::PresentationsController < ApplicationController
 
   def update
     @presentation = Presentation.find_by_cached_slug(params[:id])
-    @submit_url = admin_presentation_path(@presentation)
-    @method = :put
 
     respond_to do |format|
       if @presentation.update_attributes(params[:presentation])

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -1,0 +1,47 @@
+class Admin::SettingsController < AdminController
+  def index
+    @settings = Setting.all
+  end
+
+  def new
+    @setting = Setting.new
+  end
+
+  def create
+    @setting = Setting.new(params[:setting])
+
+    respond_to do |format|
+      if @setting.save
+        format.html { redirect_to admin_settings_path }
+      else
+        format.html { render :action => "new" }
+      end
+    end
+  end
+
+  def edit
+    @setting = Setting.find(params[:id])
+  end
+
+  def update
+    @setting = Setting.find(params[:id])
+
+    respond_to do |format|
+      if @setting.update_attributes(params[:setting])
+        format.html { redirect_to admin_settings_path }
+      else
+        format.html { render :action => "edit" }
+      end
+    end
+  end
+
+  def destroy
+    @setting = Setting.find(params[:id])
+
+    respond_to do |format|
+      if @setting.destroy
+        format.html { redirect_to admin_settings_path }
+      end
+    end
+  end
+end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,0 +1,3 @@
+class AdminController < ApplicationController
+  http_basic_authenticate_with name: BostonRuby::Admin[:username], password: BostonRuby::Admin[:password]
+end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,0 +1,21 @@
+class Setting < ActiveRecord::Base
+  validates_presence_of :key, :value
+  validates_uniqueness_of :key
+
+  def self.[](key)
+    setting = find_by_key(key)
+    setting.nil? ? nil : setting.value
+  end
+
+  def self.[]=(key, value)
+    setting = find_by_key(key)
+
+    if setting
+      setting.value = value
+    else
+      setting = new(:key => key, :value => value)
+    end
+
+    setting.save
+  end
+end

--- a/app/views/admin/settings/_form.html.erb
+++ b/app/views/admin/settings/_form.html.erb
@@ -1,0 +1,5 @@
+<%= simple_form_for [:admin, @setting], :validate => true do |form| %>
+  <%= form.input :key %>
+  <%= form.input :value, :as => :text %>
+  <%= form.submit 'Save Setting' %>
+<% end %>

--- a/app/views/admin/settings/_setting.html.erb
+++ b/app/views/admin/settings/_setting.html.erb
@@ -1,0 +1,11 @@
+<section id='<%= setting.id -%>' class='setting'>
+  <hgroup>
+  <h2>Key: <span><%= setting.key %></span></h2>
+  </hgroup>
+  <h3>Value:</h3>
+  <p><%= setting.value %></p>
+  <ul class='links'>
+      <li><%= link_to 'Edit', edit_admin_setting_path(setting) %></li>
+      <li><%= link_to 'Delete', admin_setting_path(setting), :confirm => 'Are you sure?', :method => :delete %></li>
+  </ul>
+</section>

--- a/app/views/admin/settings/edit.html.erb
+++ b/app/views/admin/settings/edit.html.erb
@@ -1,0 +1,5 @@
+<hgroup class='title'>
+  <h3>Update Setting</h3>
+</hgroup>
+
+<%= render 'form' %>

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -1,0 +1,10 @@
+<hgroup class='title'>
+<h3>Settings Admin</h3>
+</hgroup>
+
+<section id='new-setting'>
+<%= link_to 'Add a Setting', new_admin_setting_path %>
+</section>
+<section class='column'>
+    <%= render :partial => 'setting', :collection => @settings %>
+</section>

--- a/app/views/admin/settings/new.html.erb
+++ b/app/views/admin/settings/new.html.erb
@@ -1,0 +1,5 @@
+<hgroup class='title'>
+  <h3>Add a Setting</h3>
+</hgroup>
+
+<%= render 'form' %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -7,10 +7,9 @@
   <article>
     <header><h2>where</h2></header>
     <p>
-      <a href="http://maps.google.com/maps?q=1+memorial+drive+cambridge+ma">Microsoft NERD</a><br/>
-        1 Memorial Drive<br/>
-        Cambridge, MA 02142<br/>
-      <%= link_to 'Sign up required','http://guestlistapp.com/events/81732', :id => 'signup' %>
+    <%= link_to Setting['venue_name'],Setting['venue_map'] %><br/>
+    <%= raw Setting['venue_address'] %><br/>
+      <%= link_to 'Sign up required',Setting['signup_link'], :id => 'signup' %>
     </p>
   </article>
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -12,7 +12,7 @@ BostonRuby::Application.configure do
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = true
-  config.cache_store = :mem_cache_store
+  #config.cache_store = :mem_cache_store
 
   # Don't care if the mailer can't send
   config.action_mailer.raise_delivery_errors = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,5 +18,9 @@ BostonRuby::Application.routes.draw do
         get "month/:month" => :index, :as => "month"
       end
     end
+
+    resources :settings do
+
+    end
   end
 end

--- a/db/migrate/20120102012300_create_settings.rb
+++ b/db/migrate/20120102012300_create_settings.rb
@@ -1,0 +1,11 @@
+class CreateSettings < ActiveRecord::Migration
+  def change
+    create_table :settings do |t|
+      t.string :key, :null => false
+      t.string :value, :null => false
+
+      t.timestamps
+    end
+    add_index :settings, :key, :unique => true
+  end
+end

--- a/db/migrate/20120102174617_seed_settings.rb
+++ b/db/migrate/20120102174617_seed_settings.rb
@@ -1,0 +1,16 @@
+class SeedSettings < ActiveRecord::Migration
+  def up
+    [['venue_name','Microsoft NERD'],['venue_map','http://maps.google.com/maps?q=1+memorial+drive+cambridge+ma'],
+      ['venue_address','1 Memorial Drive<br>Cambridge, MA 02142'],
+      ['signup_link','http://guestlistapp.com/events/81732']].each do |key,value|
+        Setting.create(:key => key, :value => value)
+      end
+  end
+
+  def down
+    ['venue_name','venue_map','venue_address','signup_link'].each do |key|
+      setting = Setting.find_by_key key
+      setting.destroy
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20110811071228) do
+ActiveRecord::Schema.define(:version => 20120102174617) do
 
   create_table "presentation_presenters", :force => true do |t|
     t.integer  "presentation_id"
@@ -43,6 +43,15 @@ ActiveRecord::Schema.define(:version => 20110811071228) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
+
+  create_table "settings", :force => true do |t|
+    t.string   "key",        :null => false
+    t.string   "value",      :null => false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "settings", ["key"], :name => "index_settings_on_key", :unique => true
 
   create_table "slugs", :force => true do |t|
     t.string   "name"

--- a/spec/acceptance/admin_presentations_spec.rb
+++ b/spec/acceptance/admin_presentations_spec.rb
@@ -60,24 +60,4 @@ feature 'BostonRB Admin Interface', %{
     have_basic_presentation_content(@presentation_2, :should)
   end
 
-  def login
-    if page.driver.respond_to?(:basic_auth)
-      page.driver.basic_auth(name, password)
-    elsif page.driver.respond_to?(:basic_authorize)
-      page.driver.basic_authorize(name, password)
-    elsif page.driver.respond_to?(:browser) && page.driver.browser.respond_to?(:basic_authorize)
-      page.driver.browser.basic_authorize(name, password)
-    else
-      raise "I don't know how to log in!"
-    end
-  end
-
-  def name
-    'admin'
-  end
-
-  def password
-    'password'
-  end
-
 end

--- a/spec/acceptance/admin_settings_spec.rb
+++ b/spec/acceptance/admin_settings_spec.rb
@@ -1,0 +1,58 @@
+require File.expand_path(File.dirname(__FILE__) + '/acceptance_helper')
+
+feature 'BostonRB Settings Admin Interface', %{
+  As the BostonRB admin
+  I want to manage settings
+} do
+
+  background do
+    @setting_1 = Factory(:setting)
+    @setting_2 = Factory.build(:setting, :value => 'another value')
+    visit root_path
+  end
+
+  scenario 'Logging in' do
+    login
+    visit admin_settings_path
+    page.driver.response.status.should == 200
+  end
+
+  scenario 'View existing settings' do
+    login
+    visit admin_settings_path
+    have_setting_content(@setting_1, :should)
+  end
+
+  scenario 'Delete an existing settings' do
+    login
+    visit admin_settings_path
+    click_link 'Delete'
+    have_setting_content(@setting_1, :should_not)
+  end
+
+  scenario 'Edit an existing setting' do
+    login
+    visit admin_settings_path
+    click_link 'Edit'
+    @setting_1.value = 'New Setting Value'
+    fill_in 'Value', :with => @setting_1.value
+
+    click_button 'Save Setting'
+
+    have_setting_content(@setting_1, :should)
+  end
+
+  scenario 'Add new setting' do
+    login
+    visit admin_settings_path
+    click_link 'Add a Setting'
+    fill_in 'Key',     :with => @setting_2.key
+    fill_in 'Value',   :with => @setting_2.value
+
+    click_button 'Save Setting'
+
+    current_path.should eq(admin_settings_path)
+    have_setting_content(@setting_1, :should)
+    have_setting_content(@setting_2, :should)
+  end
+end

--- a/spec/acceptance/support/login.rb
+++ b/spec/acceptance/support/login.rb
@@ -1,0 +1,20 @@
+def login
+  if page.driver.respond_to?(:basic_auth)
+    page.driver.basic_auth(name, password)
+  elsif page.driver.respond_to?(:basic_authorize)
+    page.driver.basic_authorize(name, password)
+  elsif page.driver.respond_to?(:browser) && page.driver.browser.respond_to?(:basic_authorize)
+    page.driver.browser.basic_authorize(name, password)
+  else
+    raise "I don't know how to log in!"
+  end
+end
+
+def name
+  'admin'
+end
+
+def password
+  'password'
+end
+

--- a/spec/acceptance/support/setting.rb
+++ b/spec/acceptance/support/setting.rb
@@ -1,0 +1,4 @@
+def have_setting_content(setting, expectation)
+  page.send(expectation, have_content(setting.key))
+  page.send(expectation, have_content(setting.value))
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -22,3 +22,8 @@ Factory.define :presenter do |factory|
   factory.url            { 'http://twitter.com/some_presenter'        }
 end
 
+Factory.define :setting do |factory|
+  factory.key            { "Test Key #{Factory.next(:counter)}" }
+  factory.value          { 'test value' }
+end
+

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+describe Setting do
+  describe 'Validations' do
+    it { should_not have_valid(:key).when(nil, '') }
+    it { should have_valid(:key).when('some_key') }
+    it { should_not have_valid(:value).when(nil, '') }
+    it { should have_valid(:value).when('some_value') }
+
+    it 'prevents duplicate keys' do
+      setting1 = Factory(:setting)
+      setting2 = Setting.new(:key => setting1.key, :value => 'another value')
+
+      setting1.should be_valid
+      setting2.should_not have_valid(:key)
+    end
+
+    describe '[key]' do
+      it 'returns the setting\'s value by key' do
+        setting = Factory(:setting)
+        Setting[setting.key].should eq(setting.value)
+      end
+
+      it 'returns nil if there is no existing setting for the given key' do
+        setting = Factory.build(:setting)
+        Setting.find_by_key(setting.key).should be_nil
+        Setting[setting.key].should be_nil
+      end
+
+    end
+
+    describe '[key]=' do
+      it 'adds a new setting if the it doesn\'t exist' do
+        setting = Factory.build(:setting)
+        Setting.find_by_key(setting.key).should be_nil
+        Setting[setting.key] = setting.value
+        retrieved_setting = Setting.find_by_key(setting.key)
+        retrieved_setting.value.should eq(setting.value)
+      end
+
+      it 'changes the value of the setting if it exists' do
+        setting = Factory(:setting)
+        Setting[setting.key] = 'a new value'
+        retrieved_setting = Setting.find_by_key(setting.key)
+        retrieved_setting.value.should eq('a new value')
+      end
+    end
+  end
+end


### PR DESCRIPTION
The Setting model provides a dictionary for values. It can be used to
store content of the site that change from time to time (like Venue,
Sign up link, etc).

The Venue name, map link, address and sign up link have been updated to
use the Setting model. This commit includes a migration with the values
for the January meeting.

The Setting model can be used the following way
- Setting['some_key'] = 'some value' # Sets the value of some_key,
  creating the setting if necessary
- Setting['some_key'] # => 'some value'

Proper testing of Setting and the admin interface have been added

Settings admin interface available at /admin/settings

Adds AdminController which serves as base class of
Admin::PresentationController and Admin::SettingController.
AdminController contains the logic needed to force http basic
authentication.
