### PR TITLE
Boston RB Blogs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ gem 'simple_form',             '~> 1.4.0'
 gem 'friendly_id',             '~> 3.3.0.1'
 gem 'stamp',                   '~> 0.1.0'
 gem 'client_side_validations', '~> 3.1.0'
+gem 'feedzirra',               :git => 'git://github.com/pauldix/feedzirra.git' # waiting for > 0.1.1 release. See https://github.com/pauldix/feedzirra/issues/77
+gem 'twitter'
 
 # RSpec needs to be in :development group to expose generators
 # and rake tasks without having to type RAILS_ENV=test.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,18 @@
+GIT
+  remote: git://github.com/pauldix/feedzirra.git
+  revision: dee1454980e7b93022776cd047ad419da3999332
+  specs:
+    feedzirra (0.1.1)
+      activesupport (>= 3.0.8)
+      builder (>= 2.1.2)
+      curb (~> 0.7.15)
+      i18n (>= 0.5.0)
+      loofah (~> 1.2.0)
+      nokogiri (>= 1.4.4)
+      rake (>= 0.8.7)
+      rdoc (~> 3.8)
+      sax-machine (~> 0.1.0)
+
 GEM
   remote: http://rubygems.org/
   specs:
@@ -60,6 +75,7 @@ GEM
       fssm (>= 0.2.7)
       sass (~> 3.1)
     crack (0.3.1)
+    curb (0.7.17)
     database_cleaner (0.6.7)
     diff-lcs (1.1.3)
     email_spec (1.2.1)
@@ -72,6 +88,10 @@ GEM
     factory_girl_rails (1.0.1)
       factory_girl (~> 1.3)
       railties (>= 3.0.0)
+    faraday (0.7.5)
+      addressable (~> 2.2.6)
+      multipart-post (~> 1.1.3)
+      rack (>= 1.1.0, < 2)
     ffi (1.0.9)
     friendly_id (3.3.0.1)
       babosa (~> 0.3.0)
@@ -90,6 +110,8 @@ GEM
       addressable (~> 2.2.6)
     linecache19 (0.5.12)
       ruby_core_source (>= 0.1.4)
+    loofah (1.2.0)
+      nokogiri (>= 1.4.4)
     mail (2.3.0)
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
@@ -99,6 +121,7 @@ GEM
     mocha (0.9.8)
       rake
     multi_json (1.0.3)
+    multipart-post (1.1.4)
     nokogiri (1.5.0)
     pg (0.11.0)
     polyglot (0.3.3)
@@ -163,6 +186,8 @@ GEM
       sass (>= 3.1.4)
       sprockets (~> 2.0.0)
       tilt (~> 1.3.2)
+    sax-machine (0.1.0)
+      nokogiri (> 0.0.0)
     selenium-webdriver (2.10.0)
       childprocess (>= 0.2.1)
       ffi (= 1.0.9)
@@ -172,10 +197,11 @@ GEM
     simple_form (1.4.2)
       actionpack (~> 3.0)
       activemodel (~> 3.0)
+    simple_oauth (0.1.5)
     sprockets (2.0.3)
       hike (~> 1.2)
       rack (~> 1.0)
-      tilt (!= 1.3.0, ~> 1.1)
+      tilt (~> 1.1, != 1.3.0)
     sqlite3 (1.3.4)
     stamp (0.1.6)
     thor (0.14.6)
@@ -184,6 +210,11 @@ GEM
     treetop (1.4.10)
       polyglot
       polyglot (>= 0.3.1)
+    twitter (2.0.2)
+      activesupport (>= 2.3.9, < 4)
+      faraday (~> 0.7)
+      multi_json (~> 1.0)
+      simple_oauth (~> 0.1)
     tzinfo (0.3.30)
     uglifier (1.0.4)
       execjs (>= 0.3.0)
@@ -191,7 +222,7 @@ GEM
     valid_attribute (1.2.0)
     vcr (1.10.3)
     webmock (1.6.4)
-      addressable (> 2.2.5, ~> 2.2)
+      addressable (~> 2.2, > 2.2.5)
       crack (>= 0.1.7)
     xpath (0.1.4)
       nokogiri (~> 1.3)
@@ -208,6 +239,7 @@ DEPENDENCIES
   database_cleaner (~> 0.6.0)
   email_spec (~> 1.1)
   factory_girl_rails (~> 1.0.1)
+  feedzirra!
   friendly_id (~> 3.3.0.1)
   high_voltage (~> 0.9)
   jquery-rails (~> 1.0.0)
@@ -225,6 +257,7 @@ DEPENDENCIES
   sqlite3
   stamp (~> 0.1.0)
   timecop (~> 0.3.5)
+  twitter
   uglifier
   valid_attribute (~> 1.2.0)
   vcr (~> 1.10.3)

--- a/app/controllers/admin/blogs_controller.rb
+++ b/app/controllers/admin/blogs_controller.rb
@@ -1,0 +1,51 @@
+class Admin::BlogsController < ApplicationController
+  http_basic_authenticate_with name: BostonRuby::Admin[:username], password: BostonRuby::Admin[:password]
+
+  def index
+    @blogs = Blog.alphabetically.page(params[:page]).per(params[:per])
+  end
+
+  def new
+    @blog = Blog.new
+  end
+
+  def create
+    @blog = Blog.new(params[:blog])
+
+    respond_to do |format|
+      if @blog.save
+        format.html { redirect_to admin_blogs_path }
+      else
+        format.html { render :action => "new" }
+      end
+    end
+  end
+
+  def edit
+    @blog = Blog.find(params[:id])
+  end
+
+  def update
+    @blog = Blog.find(params[:id])
+    @submit_url = admin_blog_path(@blog)
+    @method = :put
+
+    respond_to do |format|
+      if @blog.update_attributes(params[:blog])
+        format.html { redirect_to admin_blogs_path }
+      else
+        format.html { render :action => "edit" }
+      end
+    end
+  end
+
+  def destroy
+    @blog = Blog.find(params[:id])
+
+    respond_to do |format|
+      if @blog.destroy
+        format.html { redirect_to admin_blogs_path }
+      end
+    end
+  end
+end

--- a/app/extensions/fake_twitter.rb
+++ b/app/extensions/fake_twitter.rb
@@ -1,0 +1,29 @@
+module FakeTwitter
+  def self.included(mod)
+    @@fake_tweets    = nil
+    @@fake_following = nil
+  end
+
+  def follow(someone)
+    fake_following << someone
+    Rails.logger.debug "FAKETWITTER: following: #{someone}"
+  end
+
+  def update(tweet)
+    fake_tweets << tweet
+    Rails.logger.debug "FAKETWITTER: tweeting: #{tweet}"
+  end
+
+  def fake_following
+    @@fake_following ||= []
+  end
+  def fake_tweets
+    @@fake_tweets ||= []
+  end
+
+  class << self
+    def activate!
+      Twitter::Client.send :include, self
+    end
+  end
+end

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -1,0 +1,71 @@
+class Blog < ActiveRecord::Base
+  validates :author,           :presence => true
+  validates :twitter_username, :format => { :with => /^@(\w)+$/i, :message => 'invalid twitter username' }
+  validates :feed_url,         :format => { :with => /^(http|https):\/\/[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(([0-9]{1,5})?\/.*)?$/i, :message => 'invalid URL' },
+                               :unless => :feed_is_file_url_for_testing?
+
+  before_save :load_from_feed, :if => :new_record?
+
+  scope :alphabetically, order(:author)
+
+  def feed_is_file_url_for_testing?
+    feed_url =~ /^file:\/\//
+  end
+
+  def load_from_feed
+    feed = Feedzirra::Feed.fetch_and_parse(feed_url)
+    update_attributes_from_feed(feed)
+    self.most_recent_post_url = most_recent_entry(feed.entries).url
+  end
+
+  def update_from_feed
+    feed = Feedzirra::Parser::Atom.new
+    feed.feed_url = feed_url
+    feed.etag     = etag
+    if most_recent_post_url
+      last_entry     = Feedzirra::Parser::AtomEntry.new
+      last_entry.url = most_recent_post_url
+      feed.entries   = [last_entry]
+    end
+
+    Feedzirra::Feed.update(feed)
+    if feed.updated?
+      update_attributes_from_feed(feed)
+      unless feed.new_entries.empty?
+        self.most_recent_post_url = most_recent_entry(feed.new_entries).url
+        tweet_entries(feed.new_entries)
+      end
+      save
+    end
+  end
+
+  def self.update_all_from_feeds
+    Blog.all.each(&:update_from_feed)
+  end
+
+  private
+  def most_recent_entry(entries)
+    @most_recent_entry ||= entries.sort_by(&:published).last
+  end
+  def update_attributes_from_feed(feed)
+    self.etag                 = feed.etag
+    self.title                = feed.title
+    self.url                  = feed.url
+  end
+
+  def tweet_entries(entries)
+    entries.each do |entry|
+      tweet_entry(entry) if entry.categories.include?('ruby')
+    end
+  end
+
+  SHORT_URL_LENGTH = 20 # should query as this may change.  See https://dev.twitter.com/docs/tco-link-wrapper/faq#Will_t.co-wrapped_links_always_be_the_same_length
+  def tweet_entry(entry)
+    tweet = "Boston Rubyist #{twitter_username} just blogged about TITLE_PLACEHOLDER #{entry.url}"
+    max_title_length = 140 - (tweet.length - 'TITLE_PLACEHOLDER'.length - entry.url.length + SHORT_URL_LENGTH)
+    truncated_title = entry.title.truncate(max_title_length)
+    tweet.gsub!('TITLE_PLACEHOLDER', truncated_title)
+
+    Twitter.update(tweet)
+  end
+end

--- a/app/views/admin/blogs/_blog.html.erb
+++ b/app/views/admin/blogs/_blog.html.erb
@@ -1,0 +1,13 @@
+<section id='<%= blog.id -%>' class='blog'>
+  <hgroup>
+    <h2><%= blog.author %></h2>
+  </hgroup>
+  <p>Title: <%= blog.title %></p>
+  <p>Twitter Username: <%= blog.twitter_username %></p>
+  <p>URL: <%= link_to blog.url %></p>
+  <p>Feed URL: <%= link_to blog.feed_url %></p>
+  <ul class='links'>
+      <li><%= link_to 'Edit', edit_admin_blog_path(blog) %></li>
+      <li><%= link_to 'Delete', admin_blog_path(blog), :confirm => 'Are you sure?', :method => :delete %></li>
+  </ul>
+</section>

--- a/app/views/admin/blogs/_form.html.erb
+++ b/app/views/admin/blogs/_form.html.erb
@@ -1,0 +1,6 @@
+<%= simple_form_for [:admin, @blog], :validate => true do |form| %>
+  <%= form.input :author %>
+  <%= form.input :feed_url, :label => 'RSS/Atom feed url' %>
+  <%= form.input :twitter_username, :label => 'Twitter Username' %>
+  <%= form.submit 'Save Blog' %>
+<% end %>

--- a/app/views/admin/blogs/edit.html.erb
+++ b/app/views/admin/blogs/edit.html.erb
@@ -1,0 +1,5 @@
+<hgroup class='title'>
+  <h3>Update Blog</h3>
+</hgroup>
+
+<%= render 'form' %>

--- a/app/views/admin/blogs/index.html.erb
+++ b/app/views/admin/blogs/index.html.erb
@@ -1,0 +1,12 @@
+<hgroup class='title'>
+  <h3>Blogs Admin</h3>
+</hgroup>
+
+<section id='new-blog'>
+ <%= link_to 'Add a blog', new_admin_blog_path %>
+</section>
+<%= paginate @blogs %>
+  <section class='column'>
+  <%= render @blogs %>
+  </section>
+<%= paginate @blogs %>

--- a/app/views/admin/blogs/new.html.erb
+++ b/app/views/admin/blogs/new.html.erb
@@ -1,0 +1,5 @@
+<hgroup class='title'>
+  <h3>Add a Blog</h3>
+</hgroup>
+
+<%= render 'form' %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,5 +33,7 @@ BostonRuby::Application.configure do
 
   BostonRuby::Admin[:username] = ENV["BOSTONRB_ADMIN_USERNAME"]
   BostonRuby::Admin[:password] = ENV["BOSTONRB_ADMIN_PASSWORD"]
+
+  FakeTwitter.activate!
 end
 

--- a/config/initializers/twitter.rb
+++ b/config/initializers/twitter.rb
@@ -1,0 +1,8 @@
+if Rails.env.production?
+  Twitter.configure do |config|
+    config.consumer_key       = ENV['TWITTER_CONSUMER_KEY']
+    config.consumer_secret    = ENV['TWITTER_CONSUMER_SECRET']
+    config.oauth_token        = ENV['TWITTER_OAUTH_TOKEN']
+    config.oauth_token_secret = ENV['TWITTER_OAUTH_TOKEN_SECRET']
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,5 +19,6 @@ BostonRuby::Application.routes.draw do
         get "month/:month" => :index, :as => "month"
       end
     end
+    resources 'blogs'
   end
 end

--- a/db/migrate/20120103153835_create_blogs.rb
+++ b/db/migrate/20120103153835_create_blogs.rb
@@ -1,0 +1,15 @@
+class CreateBlogs < ActiveRecord::Migration
+  def change
+    create_table :blogs do |t|
+      t.string :title
+      t.string :author
+      t.string :twitter_username
+      t.string :url
+      t.string :feed_url
+      t.string :etag
+      t.string :most_recent_post_url
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,19 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20110811071228) do
+ActiveRecord::Schema.define(:version => 20120103153835) do
+
+  create_table "blogs", :force => true do |t|
+    t.string   "title"
+    t.string   "author"
+    t.string   "twitter_username"
+    t.string   "url"
+    t.string   "feed_url"
+    t.string   "etag"
+    t.string   "most_recent_post_url"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
 
   create_table "presentation_presenters", :force => true do |t|
     t.integer  "presentation_id"

--- a/lib/tasks/cron.rake
+++ b/lib/tasks/cron.rake
@@ -1,4 +1,5 @@
 desc "Cron Tasks"
 task :cron => :environment do
   BostonRbCalendar.cache_next_event
+  Blog.update_all_from_feeds
 end

--- a/spec/acceptance/admin_blogs_spec.rb
+++ b/spec/acceptance/admin_blogs_spec.rb
@@ -1,0 +1,86 @@
+require File.expand_path(File.dirname(__FILE__) + '/acceptance_helper')
+
+feature 'BostonRB Admin Interface', %{
+  As the BostonRB admin
+  I want to manage blogs
+} do
+
+  include Blog::TestHelpers
+
+  let(:blog_feed_directory) { "#{Rails.root}/tmp/blog_feeds" }
+  let(:blog_1) { Factory(:blog, :author => 'Alex', :twitter_username => '@alex', :feed_url => "file://#{blog_feed_directory}/alex_atom.xml") }
+  let(:blog_2) { Factory.build(:blog, :feed_url => "file://#{blog_feed_directory}/pat_feedburner_atom.xml")                                    }
+
+  background do
+    setup_blog_feeds('12_01_2011')
+    visit root_path
+    blog_1
+  end
+
+  scenario 'Logging in' do
+    login
+    visit admin_blogs_path
+    page.driver.response.status.should == 200
+  end
+
+  scenario 'View existing blogs' do
+    login
+    visit admin_blogs_path
+    have_basic_blog_content(blog_1, :should)
+  end
+
+  scenario 'Delete an existing blog' do
+    login
+    visit admin_blogs_path
+    click_link 'Delete'
+    have_basic_blog_content(blog_1, :should_not)
+  end
+
+  scenario 'Edit an existing blog' do
+    login
+    visit admin_blogs_path
+    click_link 'Edit'
+    blog_1.author = 'Alex Rothenberg'
+    fill_in 'Author', :with => blog_1.author
+
+    click_button 'Save Blog'
+
+    have_basic_blog_content(blog_1, :should)
+  end
+
+  scenario 'Add new blog' do
+    login
+    visit admin_blogs_path
+    click_link 'Add a blog'
+    fill_in 'Author',            :with => blog_2.author
+    fill_in 'Twitter Username',  :with => blog_2.twitter_username
+    fill_in 'RSS/Atom feed url', :with => blog_2.feed_url
+
+    click_button 'Save Blog'
+
+    current_path.should eq(admin_blogs_path)
+    have_basic_blog_content(blog_1, :should)
+    have_basic_blog_content(blog_2, :should)
+  end
+
+  def login
+    if page.driver.respond_to?(:basic_auth)
+      page.driver.basic_auth(name, password)
+    elsif page.driver.respond_to?(:basic_authorize)
+      page.driver.basic_authorize(name, password)
+    elsif page.driver.respond_to?(:browser) && page.driver.browser.respond_to?(:basic_authorize)
+      page.driver.browser.basic_authorize(name, password)
+    else
+      raise "I don't know how to log in!"
+    end
+  end
+
+  def name
+    'admin'
+  end
+
+  def password
+    'password'
+  end
+
+end

--- a/spec/acceptance/support/blog.rb
+++ b/spec/acceptance/support/blog.rb
@@ -1,0 +1,9 @@
+def have_blog_content(presentation, expectation)
+  have_basic_blog_content(presentation, expectation)
+end
+
+def have_basic_blog_content(presentation, expectation)
+  page.send(expectation, have_content(presentation.author))
+  page.send(expectation, have_content(presentation.twitter_username))
+  page.send(expectation, have_content(presentation.feed_url))
+end

--- a/spec/acceptance/tweets_new_blog_posts_spec.rb
+++ b/spec/acceptance/tweets_new_blog_posts_spec.rb
@@ -1,0 +1,39 @@
+require File.expand_path(File.dirname(__FILE__) + '/acceptance_helper')
+
+feature 'BostonRB Blogs', %{
+  As a BostonRB member
+  I want to see ruby posts by BostonRB bloggers tweeted by the @bostonrb account
+} do
+
+  include Blog::TestHelpers
+  let(:blog_feed_directory) { "#{Rails.root}/tmp/blog_feeds" }
+  let(:alex_blog ) { Factory(:blog, :author => 'Alex',  :twitter_username => '@alex',  :feed_url => "file://#{blog_feed_directory}/alex_atom.xml"          ) }
+  let(:pat_blog  ) { Factory(:blog, :author => 'Pat',   :twitter_username => '@pat',   :feed_url => "file://#{blog_feed_directory}/pat_feedburner_atom.xml") }
+  let(:brian_blog) { Factory(:blog, :author => 'Brian', :twitter_username => '@brian', :feed_url => "file://#{blog_feed_directory}/brian_rss.xml"          ) }
+
+  background do
+    FakeTwitter.activate!
+
+    setup_blog_feeds('12_01_2011')
+    [alex_blog, pat_blog, brian_blog] # lazy load them now
+  end
+
+  scenario 'Not tweeting when there are no new posts' do
+    setup_blog_feeds('12_01_2011')
+    Blog.update_all_from_feeds
+
+    Twitter.fake_tweets.should be_empty
+  end
+
+  scenario 'Tweeting new ruby posts from all blogs' do
+    setup_blog_feeds('1_11_2012')
+    Blog.update_all_from_feeds
+
+    Twitter.fake_tweets.should include 'Boston Rubyist @alex just blogged about My Second Ruby Post http://alex.com/2011/second_ruby_post.html'
+    Twitter.fake_tweets.should include 'Boston Rubyist @alex just blogged about My First Ruby Post http://alex.com/2011/first_ruby_post.html'
+    Twitter.fake_tweets.should include 'Boston Rubyist @pat just blogged about How to Customize Twitter Bootstrap http://patshaughnessy.net/2012/1/11/twitter-bootstrap'
+    Twitter.fake_tweets.should include 'Boston Rubyist @brian just blogged about New Ruby stuff http://bcardarella.com/post/8682011111'
+    Twitter.fake_tweets.size.should == 4
+  end
+
+end

--- a/spec/blog_feeds/12_01_2011/alex_atom.xml
+++ b/spec/blog_feeds/12_01_2011/alex_atom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>My Blog</title>
+  <link href="http://alexrothenberg.com/atom.xml" rel="self"/>
+  <link href="http://alexrothenberg.com/"/>
+  <updated>2011-11-24T23:19:26-08:00</updated>
+  <id>http://alexrothenberg.com/</id>
+  <author>
+    <name>Alex</name>
+  </author>
+  <entry>
+    <title>My First Post</title>
+    <category/>
+    <link href="http://alexrothenberg.com/2011/first_post.html"/>
+    <updated>2011-11-24T00:00:00</updated>
+    <id>http://alexrothenberg.com/2011/first_post.html</id>
+    <content type="html">really interesting content goes here</content>
+  </entry>
+</feed>

--- a/spec/blog_feeds/12_01_2011/brian_rss.xml
+++ b/spec/blog_feeds/12_01_2011/brian_rss.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0">
+  <channel>
+    <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="hub" href="http://tumblr.superfeedr.com/"/>
+    <description/>
+    <title>Brian Cardarella's Blog</title>
+    <generator>Tumblr (3.0; @bcardarella)</generator>
+    <link>http://bcardarella.com/</link>
+    <item>
+      <title>Clean up trailing whitespace</title>
+      <description>the content goes here</description>
+      <link>http://bcardarella.com/post/8682039114</link>
+      <guid>http://bcardarella.com/post/8682039114</guid>
+      <pubDate>Tue, 09 Aug 2011 03:16:00 -0400</pubDate>
+      <category>osx</category>
+      <category>sed</category>
+      <category>trailing whitespace</category>
+    </item>
+    <item>
+      <title>The State Open Source Development</title>
+      <description>content</description>
+      <link>http://bcardarella.com/post/8008403283</link>
+      <guid>http://bcardarella.com/post/8008403283</guid>
+      <pubDate>Sun, 24 Jul 2011 14:25:00 -0400</pubDate>
+    </item>
+    <item>
+      <title>Every pub and cafe should have free wifi and power.</title>
+      <description>content</description>
+      <link>http://bcardarella.com/post/7044433281</link>
+      <guid>http://bcardarella.com/post/7044433281</guid>
+      <pubDate>Wed, 29 Jun 2011 10:17:00 -0400</pubDate>
+    </item>
+    <item>
+      <title>ClientSideValidations for Rails 3.1 and 2.3.x backport</title>
+      <description>content</description>
+      <link>http://bcardarella.com/post/6733907607</link>
+      <guid>http://bcardarella.com/post/6733907607</guid>
+      <pubDate>Mon, 20 Jun 2011 17:17:00 -0400</pubDate>
+    </item>
+  </channel>
+</rss>

--- a/spec/blog_feeds/12_01_2011/pat_feedburner_atom.xml
+++ b/spec/blog_feeds/12_01_2011/pat_feedburner_atom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" media="screen" href="/~d/styles/atom10full.xsl"?>
+<?xml-stylesheet type="text/css" media="screen" href="http://feeds.feedburner.com/~d/styles/itemcontent.css"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Pat Shaughnessy</title>
+  <id>http://patshaughnessy.net</id>
+  <updated>2008-09-03T00:00:00Z</updated>
+  <author>
+    <name/>
+  </author>
+  <atom10:link xmlns:atom10="http://www.w3.org/2005/Atom" rel="self" type="application/atom+xml" href="http://feeds.feedburner.com/patshaughnessy"/>
+  <feedburner:info xmlns:feedburner="http://rssnamespace.org/feedburner/ext/1.0" uri="patshaughnessy"/>
+  <atom10:link xmlns:atom10="http://www.w3.org/2005/Atom" rel="hub" href="http://pubsubhubbub.appspot.com/"/>
+  <entry>
+    <title>My name is pat</title>
+    <link href="http://patshaughnessy.net/2011/12/14/my-name-is-pat" rel="alternate"/>
+    <id>http://patshaughnessy.net/2011/12/14/my-name-is-pat</id>
+    <category>my-name</category>
+    <category>personal</category>
+    <published>2011-12-14T00:00:00Z</published>
+    <updated>2011-12-14T00:00:00Z</updated>
+    <author>
+      <name/>
+    </author>
+    <summary type="html">a summary of this article</summary>
+    <content type="html">the content</content>
+  </entry>
+  <entry>
+    <title>Two ways of using Redis to build a NoSQL autocomplete search index</title>
+    <link href="http://patshaughnessy.net/2011/11/29/two-ways-of-using-redis-to-build-a-nosql-autocomplete-search-index" rel="alternate" />
+    <id>http://patshaughnessy.net/2011/11/29/two-ways-of-using-redis-to-build-a-nosql-autocomplete-search-index</id>
+    <category>redis</category>
+    <category>nosql</category>
+    <published>2011-11-29T00:00:00Z</published>
+    <updated>2011-11-29T00:00:00Z</updated>
+    <author>
+      <name />
+    </author>
+    <summary type="html">a summary of this article</summary>
+    <content type="html">the content</content>
+  </entry>
+  <entry>
+    <title>Finding your soulmate: autocomplete with Redis in Rails 3.1</title>
+    <link href="http://patshaughnessy.net/2011/11/23/finding-your-soulmate-autocomplete-with-redis-in-rails-3-1" rel="alternate" />
+    <id>http://patshaughnessy.net/2011/11/23/finding-your-soulmate-autocomplete-with-redis-in-rails-3-1</id>
+    <category>redis</category>
+    <category>ruby</category>
+    <category>autocomplete</category>
+    <published>2011-11-23T00:00:00Z</published>
+    <updated>2011-11-23T00:00:00Z</updated>
+    <author>
+      <name />
+    </author>
+    <summary type="html">a summary of this article</summary>
+    <content type="html">the content</content>
+  </entry>
+</feed>

--- a/spec/blog_feeds/1_11_2012/alex_atom.xml
+++ b/spec/blog_feeds/1_11_2012/alex_atom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+ <title>My Blog</title>
+ <link href="http://alex.com/atom.xml" rel="self"/>
+ <link href="http://alex.com/"/>
+ <updated>2011-11-24T23:19:26-08:00</updated>
+ <id>http://alex.com/</id>
+ <author>
+   <name>Alex</name>
+ </author>
+ <entry>
+   <title>My Second Ruby Post</title>
+   <category>ruby</category>
+   <link href="http://alex.com/2011/second_ruby_post.html"/>
+   <updated>2012-01-01T00:00:00</updated>
+   <id>http://alex.com/2012/second_ruby_post.html</id>
+   <content type="html">content goes here</content>
+ </entry>
+ <entry>
+   <title>My First Mobile Post</title>
+   <category>mobile</category>
+   <link href="http://alex.com/2011/first_mobile_post.html"/>
+   <updated>2011-12-10T00:00:00</updated>
+   <id>http://alex.com/2011/first_mobile_post.html</id>
+   <content type="html">content goes here</content>
+ </entry>
+ <entry>
+   <title>My First Ruby Post</title>
+   <category>ruby</category>
+   <link href="http://alex.com/2011/first_ruby_post.html"/>
+   <updated>2011-12-07T00:00:00</updated>
+   <id>http://alex.com/2011/first_ruby_post.html</id>
+   <content type="html">content goes here</content>
+ </entry>
+ <entry>
+   <title>My First Post</title>
+   <category></category>
+   <link href="http://alex.com/2011/first_post.html"/>
+   <updated>2011-11-24T00:00:00</updated>
+   <id>http://alex.com/2011/first_post.html</id>
+   <content type="html">really interesting content goes here</content>
+ </entry>
+</feed>

--- a/spec/blog_feeds/1_11_2012/brian_rss.xml
+++ b/spec/blog_feeds/1_11_2012/brian_rss.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0">
+  <channel>
+    <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="hub" href="http://tumblr.superfeedr.com/"/>
+    <description/>
+    <title>Brian Cardarella's Blog</title>
+    <generator>Tumblr (3.0; @bcardarella)</generator>
+    <link>http://bcardarella.com/</link>
+    <item>
+      <title>Happy New Year</title>
+      <description>the content goes here</description>
+      <link>http://bcardarella.com/post/8682022222</link>
+      <guid>http://bcardarella.com/post/8682022222</guid>
+      <pubDate>Mon, 01 Jan 2012 03:16:00 -0400</pubDate>
+      <category>NYE</category>
+    </item>
+    <item>
+      <title>New Ruby stuff</title>
+      <description>the content goes here</description>
+      <link>http://bcardarella.com/post/8682011111</link>
+      <guid>http://bcardarella.com/post/8682011111</guid>
+      <pubDate>Tue, 27 Dec 2011 03:16:00 -0400</pubDate>
+      <category>boston</category>
+      <category>ruby</category>
+      <category>stuff</category>
+    </item>
+    <item>
+      <title>Clean up trailing whitespace</title>
+      <description>the content goes here</description>
+      <link>http://bcardarella.com/post/8682039114</link>
+      <guid>http://bcardarella.com/post/8682039114</guid>
+      <pubDate>Tue, 09 Aug 2011 03:16:00 -0400</pubDate>
+      <category>osx</category>
+      <category>sed</category>
+      <category>trailing whitespace</category>
+    </item>
+    <item>
+      <title>The State Open Source Development</title>
+      <description>content</description>
+      <link>http://bcardarella.com/post/8008403283</link>
+      <guid>http://bcardarella.com/post/8008403283</guid>
+      <pubDate>Sun, 24 Jul 2011 14:25:00 -0400</pubDate>
+    </item>
+    <item>
+      <title>Every pub and cafe should have free wifi and power.</title>
+      <description>content</description>
+      <link>http://bcardarella.com/post/7044433281</link>
+      <guid>http://bcardarella.com/post/7044433281</guid>
+      <pubDate>Wed, 29 Jun 2011 10:17:00 -0400</pubDate>
+    </item>
+    <item>
+      <title>ClientSideValidations for Rails 3.1 and 2.3.x backport</title>
+      <description>content</description>
+      <link>http://bcardarella.com/post/6733907607</link>
+      <guid>http://bcardarella.com/post/6733907607</guid>
+      <pubDate>Mon, 20 Jun 2011 17:17:00 -0400</pubDate>
+    </item>
+  </channel>
+</rss>

--- a/spec/blog_feeds/1_11_2012/pat_feedburner_atom.xml
+++ b/spec/blog_feeds/1_11_2012/pat_feedburner_atom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" media="screen" href="/~d/styles/atom10full.xsl"?>
+<?xml-stylesheet type="text/css" media="screen" href="http://feeds.feedburner.com/~d/styles/itemcontent.css"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Pat Shaughnessy</title>
+  <id>http://patshaughnessy.net</id>
+  <updated>2008-09-03T00:00:00Z</updated>
+  <author>
+    <name/>
+  </author>
+  <atom10:link xmlns:atom10="http://www.w3.org/2005/Atom" rel="self" type="application/atom+xml" href="http://feeds.feedburner.com/patshaughnessy"/>
+  <feedburner:info xmlns:feedburner="http://rssnamespace.org/feedburner/ext/1.0" uri="patshaughnessy"/>
+  <atom10:link xmlns:atom10="http://www.w3.org/2005/Atom" rel="hub" href="http://pubsubhubbub.appspot.com/"/>
+  <entry>
+    <title>How to Customize Twitter Bootstrap</title>
+    <link href="http://patshaughnessy.net/2012/1/11/twitter-bootstrap" rel="alternate"/>
+    <id>http://patshaughnessy.net/2012/1/11/twitter-bootstrap</id>
+    <category>twitter bootstrap</category>
+    <category>ruby</category>
+    <category>rails</category>
+    <published>2012-01-11T00:00:00Z</published>
+    <updated>2012-01-11T00:00:00Z</updated>
+    <author>
+      <name/>
+    </author>
+    <summary type="html">summary here</summary>
+    <content type="html">content here</content>
+  </entry>
+  <entry>
+    <title>Never create Ruby strings longer than 23 characters</title>
+    <link href="http://patshaughnessy.net/2012/1/4/never-create-ruby-strings-longer-than-23-characters" rel="alternate"/>
+    <id>http://patshaughnessy.net/2012/1/4/never-create-ruby-strings-longer-than-23-characters</id>
+    <published>2012-01-04T00:00:00Z</published>
+    <updated>2012-01-04T00:00:00Z</updated>
+    <author>
+      <name/>
+    </author>
+    <summary type="html">a summary of this article</summary>
+    <content type="html">the content</content>
+  </entry>
+  <entry>
+    <title>My name is pat</title>
+    <link href="http://patshaughnessy.net/2011/12/14/my-name-is-pat" rel="alternate"/>
+    <id>http://patshaughnessy.net/2011/12/14/my-name-is-pat</id>
+    <category>my-name</category>
+    <category>personal</category>
+    <published>2011-12-14T00:00:00Z</published>
+    <updated>2011-12-14T00:00:00Z</updated>
+    <author>
+      <name/>
+    </author>
+    <summary type="html">a summary of this article</summary>
+    <content type="html">the content</content>
+  </entry>
+  <entry>
+    <title>Two ways of using Redis to build a NoSQL autocomplete search index</title>
+    <link href="http://patshaughnessy.net/2011/11/29/two-ways-of-using-redis-to-build-a-nosql-autocomplete-search-index" rel="alternate" />
+    <id>http://patshaughnessy.net/2011/11/29/two-ways-of-using-redis-to-build-a-nosql-autocomplete-search-index</id>
+    <category>redis</category>
+    <category>nosql</category>
+    <published>2011-11-29T00:00:00Z</published>
+    <updated>2011-11-29T00:00:00Z</updated>
+    <author>
+      <name />
+    </author>
+    <summary type="html">a summary of this article</summary>
+    <content type="html">the content</content>
+  </entry>
+  <entry>
+    <title>Finding your soulmate: autocomplete with Redis in Rails 3.1</title>
+    <link href="http://patshaughnessy.net/2011/11/23/finding-your-soulmate-autocomplete-with-redis-in-rails-3-1" rel="alternate" />
+    <id>http://patshaughnessy.net/2011/11/23/finding-your-soulmate-autocomplete-with-redis-in-rails-3-1</id>
+    <category>redis</category>
+    <category>ruby</category>
+    <category>autocomplete</category>
+    <published>2011-11-23T00:00:00Z</published>
+    <updated>2011-11-23T00:00:00Z</updated>
+    <author>
+      <name />
+    </author>
+    <summary type="html">a summary of this article</summary>
+    <content type="html">the content</content>
+  </entry>
+</feed>

--- a/spec/blog_feeds/README.md
+++ b/spec/blog_feeds/README.md
@@ -1,0 +1,4 @@
+We cannot use VCR to test the blog feeds because they do not support Curl::Multi which is what feedzirra uses.  We test using file://path/to/these/xml/files instead.
+
+* [VCR readme](https://github.com/myronmarston/vcr) "Curb (when using WebMock -- only supports Curl::Easy at the moment)"
+* [Feedzirra Discussion](https://groups.google.com/forum/#!topic/feedzirra/J58t3uJTSWw) see 7/7/11 comment by bramswenson "since feedzirra is using Curl::Multi, it isn't very testable (with vcr)"

--- a/spec/extensions/fake_twitter_spec.rb
+++ b/spec/extensions/fake_twitter_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe FakeTwitter do
+  before do
+    FakeTwitter.activate!
+  end
+
+  describe '.follow' do
+    it 'should remember who we start following' do
+      Twitter.follow 'brian'
+      Twitter.follow 'alex'
+      Twitter.fake_following.should == ['brian', 'alex']
+    end
+  end
+
+  describe '.update' do
+    it 'should remember our tweets' do
+      Twitter.update '@bostonrb meeting starting'
+      Twitter.update '@bostonrb meeting just ended'
+      Twitter.fake_tweets.should == ['@bostonrb meeting starting', '@bostonrb meeting just ended']
+    end
+  end
+
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -22,3 +22,8 @@ Factory.define :presenter do |factory|
   factory.url            { 'http://twitter.com/some_presenter'        }
 end
 
+Factory.define :blog do |factory|
+  factory.author           { 'Brian Cardarella'                      }
+  factory.twitter_username { |blog| "@#{blog.author.gsub(' ', '_')}" }
+  factory.feed_url         { 'http://a.blog.com/feed'                }
+end

--- a/spec/models/blog_spec.rb
+++ b/spec/models/blog_spec.rb
@@ -1,0 +1,104 @@
+require 'spec_helper'
+
+describe Blog do
+  describe 'Validations' do
+    let(:blog) { Factory.build :blog }
+    before { blog.stubs(:load_from_feed) }
+    subject { blog }
+    it { should_not have_valid(:author).when(nil, '') }
+    it { should_not have_valid(:twitter_username).when(nil) }
+    it { should_not have_valid(:twitter_username).when('not_starting_with_at_sign') }
+    it { should_not have_valid(:feed_url).when('badurl') }
+    it { should_not have_valid(:feed_url).when(nil) }
+  end
+
+  describe '.alphabetically' do
+    let(:brian) { Factory.build :blog, :author => 'Brian' }
+    let(:pat)   { Factory.build :blog, :author => 'Pat'   }
+    let(:alex)  { Factory.build :blog, :author => 'Alex'  }
+    before do
+      [brian, pat, alex].each do |blog|
+        blog.stubs(:load_from_feed)
+        blog.save
+      end
+    end
+    subject { Blog.alphabetically }
+    it { should == [alex, brian, pat] }
+  end
+
+  describe '#load_from_feed (called after_create)' do
+    let(:feed        ) { stub(:etag => '123456789', :title => 'Some Blog', :url => 'http://some.blog.com', :entries => feed_entries) }
+    let(:entry_1     ) { stub(:published => 1.day.ago,  :url => 'http://some.blog.com/new_post') }
+    let(:entry_2     ) { stub(:published => 5.days.ago, :url => 'http://some.blog.com/old_post') }
+    let(:feed_entries) { [entry_1, entry_2] }
+    let(:brian_blog  ) { Factory :blog, feed_url: 'http://some.blog.com/feed'}
+    before do
+      Feedzirra::Feed.expects(:fetch_and_parse).with('http://some.blog.com/feed').returns(feed)
+    end
+    subject { brian_blog }
+    its(:title) { should == 'Some Blog' }
+    its(:url) { should == 'http://some.blog.com' }
+    its(:most_recent_post_url) { should == 'http://some.blog.com/new_post' }
+  end
+
+  describe '#update_from_feed' do
+    let(:brian_blog) { Factory.build :blog, twitter_username: '@brian', feed_url: 'http://some.blog.com/feed', most_recent_post_url: 'http://some.blog.com/old_post'}
+    before do
+      brian_blog.stubs(:load_from_feed)
+      brian_blog.save
+
+      Twitter.stubs(:update)
+    end
+    describe 'when there are updates' do
+      let(:long_title      ) { 'This Title Goes On And On For Way Too Long. Why Can I Not Be More Concise? This Will Not Fit In A Tweet :(' }
+      let(:short_title     ) { 'Something Short and Sweet' }
+      let(:new_entry       ) { stub(:published => 1.day.ago,  :url => 'http://some.blog.com/newest_post', :categories => ['ruby'], :title => long_title ) }
+      let(:irrelevant_entry) { stub(:published => 2.days.ago, :url => 'http://some.blog.com/php_post',    :categories => ['php' ], :title => 'PHP stuff') }
+      let(:newer_entry     ) { stub(:published => 5.days.ago, :url => 'http://some.blog.com/new_post',    :categories => ['ruby'], :title => short_title) }
+      let(:old_entry       ) { stub(:published => 1.month.ago) }
+      let(:new_entries     ) { [newer_entry, new_entry] }
+      before do
+        Feedzirra::Parser::Atom.any_instance.stubs(:updated?).returns(true)
+        Feedzirra::Parser::Atom.any_instance.stubs(:new_entries).returns(new_entries)
+        Feedzirra::Parser::Atom.any_instance.stubs(:entries).returns([newer_entry, irrelevant_entry, new_entry, old_entry])
+        Feedzirra::Feed.expects(:update)
+
+        brian_blog.update_from_feed
+      end
+      subject { brian_blog }
+      its(:most_recent_post_url) { should == 'http://some.blog.com/newest_post' }
+      describe 'tweeting' do
+        subject { Twitter }
+        it { should have_received(:update).with('Boston Rubyist @brian just blogged about Something Short and Sweet http://some.blog.com/new_post') }
+        it { should have_received(:update).with('Boston Rubyist @brian just blogged about This Title Goes On And On For Way Too Long. Why Can I Not Be More Concise? ... http://some.blog.com/newest_post') }
+        it { should_not have_received(:update).with('Boston Rubyist @brian just blogged about PHP stuff http://some.blog.com/php_post') }
+      end
+    end
+    describe 'when there are no updates' do
+      before do
+        Feedzirra::Parser::Atom.any_instance.stubs(:updated?).returns(false)
+        Feedzirra::Feed.expects(:update)
+
+        brian_blog.update_from_feed
+      end
+      subject { brian_blog }
+      its(:most_recent_post_url) { should == 'http://some.blog.com/old_post' }
+      describe 'tweeting' do
+        subject { Twitter }
+        it { should_not have_received(:update) }
+      end
+    end
+  end
+
+  describe '#update_all_from_feeds' do
+    let(:brian) { Factory :blog }
+    let(:alex ) { Factory :blog }
+    before do
+      Blog.any_instance.stubs(:load_from_feed)
+      Feedzirra::Parser::Atom.any_instance.stubs(:updated?).returns(false)
+    end
+    it 'should update each blog in turn' do
+      Blog.update_all_from_feeds
+    end
+  end
+end

--- a/spec/support/blog.rb
+++ b/spec/support/blog.rb
@@ -1,0 +1,7 @@
+require 'fileutils'
+module Blog::TestHelpers
+  def setup_blog_feeds(date)
+    FileUtils.rm    "#{Rails.root}/tmp/blog_feeds"
+    FileUtils.ln_sf "#{File.expand_path("../../blog_feeds/#{date}", __FILE__)}", "#{Rails.root}/tmp/blog_feeds"
+  end
+end


### PR DESCRIPTION
- Track blogs (admin interface)
- tweet new posts with 'ruby' category as the come in (really when rake cron runs)

This is a simpler take on the "tweeting ruby blog posts" story we discussed in #140. 

I've got a test instance running and tweeting at https://twitter.com/#!/test_bosrb so you can see the tweets it generates.  No tweets when you create a blog then a tweet for each ruby post it sees in the feed after that.

@bcardarella

Is this closer to what you were thinking of?
