### PR TITLE
Specify https://rubygems.org in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 ruby '1.9.3'
 
 gem 'rails',                   '~> 3.2.12'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
       sax-machine (~> 0.2.0.rc1)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     actionmailer (3.2.12)
       actionpack (= 3.2.12)


### PR DESCRIPTION
This eliminates a warning from Bundler.
