### PR TITLE
Add time to project night description on home page

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -39,7 +39,7 @@
   <article>
     <header><h2>more</h2></header>
     <p>
-      Project nights happen on the first Tuesday of the month. We welcome all skill levels and encourage people that are "Ruby curious" to attend. At the Project Night people do things like getting their first Rails app running or writing and releasing <a href="http://rubygems.org">Ruby gems</a>.
+      Project nights happen on the first Tuesday of the month, 6:30pm–9:30pm. We welcome all skill levels and encourage people that are "Ruby curious" to attend. At the Project Night people do things like getting their first Rails app running or writing and releasing <a href="http://rubygems.org">Ruby gems</a>.
       <br/><br/>
       We will be writing code so bring a laptop and enthusiasm. For those without a project idea be willing to help others.
     </p>


### PR DESCRIPTION
I felt like I had to hunt to find out the start time of the project night. I think adding the time to the home page will save time for folks looking for the same info.
