### PR TITLE
Fix Railsbridge Boston URL.

### DIFF
--- a/app/views/pages/project_night.html.erb
+++ b/app/views/pages/project_night.html.erb
@@ -41,7 +41,7 @@
     <p>
       Whether you are on a Mac, Linux, or Windows, getting setup on Rails is easy.
       <br/>
-      Our friends at <a href="http://http://www.railsbridgeboston.org/">Railsbridge Boston</a>
+      Our friends at <a href="http://www.railsbridgeboston.org/">Railsbridge Boston</a>
       have some
       great <%= link_to "Setup Instructions", "http://www.railsbridgeboston.org/installfest" %>
       on getting your system setup with Rails.


### PR DESCRIPTION
Removed a duplicate **http://** from the link to Railsbridge Boston.
