### PR TITLE
Fix broken links and update copy on Project Night page

### DIFF
--- a/app/views/pages/project_night.html.erb
+++ b/app/views/pages/project_night.html.erb
@@ -4,7 +4,7 @@
       <h2>what</h2>
     </header>
     <p>
-      Project Night is a great night to get help getting Rails installed on your system,
+      Project Night is a great night to receive help getting Rails installed on your system,
       work on and get help with your own project, hack on some open source, and meet other
       Rubyists in the Boston area.</br>
       <br/>
@@ -39,12 +39,12 @@
   <article>
     <header><h2>setup</h2></header>
     <p>
-      Whether you are on a Mac, Linux, or Windows, getting setup on Rails is easy.
+      Whether you are on a Mac, Linux, or Windows, getting set up on Rails is easy.
       <br/>
       Our friends at <%= link_to "RailsBridge Boston", "http://www.railsbridgeboston.org/" %>
       have some
-      great <%= link_to "Setup Instructions", "http://docs.railsbridgeboston.org/installfest/" %>
-      on getting your system setup with Rails.
+      great <%= link_to "Set-Up Instructions", "http://docs.railsbridgeboston.org/installfest/" %>
+      on getting your system set up with Rails.
       <br/>
 
     </p>
@@ -53,10 +53,10 @@
   <article>
     <header><h2>more</h2></header>
     <p>
-      We welcome all skill levels and encourage people that are "Ruby curious" to attend.
+      We welcome all skill levels, and encourage people that are "Ruby curious" to attend.
       <br/>
       <br/>
-      We will be writing code so bring a laptop and enthusiasm. For those without a project idea be
+      We will be writing code so bring a laptop and enthusiasm. For those without a project idea, be
       willing to help others.
     </p>
   </article>


### PR DESCRIPTION
It looks like RailsBridge updated their site shortly after #169 was accepted, so the installfest URL broke. I updated both RBB links to use `link_to` syntax. This also includes some changes to the description in an effort to improve clarity.
